### PR TITLE
Add missing array indicator in IMM.yaml

### DIFF
--- a/imm.yaml
+++ b/imm.yaml
@@ -109,6 +109,7 @@
     Name: Packaging
     Id: 547fd9f5-9caf-449f-82d9-4fba9e7ce13a
     Measures:
+        -
             Score: 0
             Description: None
 -


### PR DESCRIPTION
The Packaging entry was missing a `-` causing all badge rendering to fail.